### PR TITLE
Replace path field with composedPath function

### DIFF
--- a/src/abubumain.js
+++ b/src/abubumain.js
@@ -5540,8 +5540,8 @@ class Plot2D{
         }
         this._clrm.image.plot = this ;
         this._clrm.image.init = function(e){
-            e.path[0].plot.init() ;
-            e.path[0].plot.render() ;
+            e.composedPath()[0].plot.init() ;
+            e.composedPath()[0].plot.render() ;
         }
         this._clrm.image.onload = (e) => this._clrm.image.init(e) ;
     }


### PR DESCRIPTION
When attempting to call the `init()` method on a `Plot2D` I would get the following error:
```
Uncaught TypeError: e.path is undefined
```
From examining the stack trace, the `drawColorbar` function seemed to be the culprit. I suspect that the goal of the modified lines was to use the path to get the image found at the first index of the array returned by `composedPath()`. As far as I could tell, however, the object does not have a `path` field.

Let me know if there are any issues with this fix, as I certainly don't have enough context to know that this is the correct solution. However, this change did remove the error when I was running it.